### PR TITLE
Add code to insert idiosyncratic UseWithIRI row in term versions CSV

### DIFF
--- a/build/generate_term_versions.py
+++ b/build/generate_term_versions.py
@@ -84,6 +84,23 @@ for row_index,row in accumulated_frame.iterrows():
             normative_doc_row.append(row[column_mapping['accum']])
     normative_doc_list.append(normative_doc_row)
 
+# special handling for http://rs.tdwg.org/dwc/terms/attributes/UseWithIRI. Eventually we want to eliminate this.
+use_with_iri_row = ['http://rs.tdwg.org/dwc/terms/attributes/UseWithIRI-2017-10-06',
+  'UseWithIRI',
+  'UseWithIRI',
+  'The category of terms that are recommended to have an IRI as a value.',
+  'A utility class to organize the dwciri: terms.',
+  '',
+  'http://www.w3.org/2000/01/rdf-schema#Class',
+  '2017-10-06',
+  'recommended',
+  '',
+  'http://www.w3.org/2000/01/rdf-schema#Class',
+  'http://rs.tdwg.org/dwc/terms/attributes/UseWithIRI',
+  'not in ABCD',
+  '']
+normative_doc_list.append(use_with_iri_row)
+
 # Turn list of lists into dataframe
 normative_doc_df = pd.DataFrame(normative_doc_list, columns = column_headers)
 # Set the row label as the version IRI


### PR DESCRIPTION
@tucotuco I figured it out. The special code for inserting that row in the table is [here](https://github.com/tdwg/dwc/blob/master/build/generate_term_versions.py#L122) in the DwC script. I took it out in [this commit](https://github.com/tdwg/chrono/commit/93b1fcd4b5cc35b947f9ec5960a4ba03c9f24c09#diff-751a44b6c8da4351098e0549f9e27a2e14b92f086caba961cce8d2057dff9da7) because at the time there were no IRI terms. When I added the chronoiri namespace terms in [this commit](https://github.com/tdwg/chrono/commit/641736ec6765acb59c9f0d6d861acf5c6a44580f#diff-751a44b6c8da4351098e0549f9e27a2e14b92f086caba961cce8d2057dff9da7), I didn't put that code back in. So that's why it didn't generate the special row in the table. 

I'm still a bit mystified as to how it worked last time, but maybe you did some hand-editing of the CSV that generates the QRG or something. In any case, when I run the `generate_term_versions.py` script as modified in this branch, it generates exactly the same CSV as the one you are currently using to create the QRG. So I think this should fix the problem.